### PR TITLE
fix: improve email validation regex pattern

### DIFF
--- a/src/main/java/com/finance/manager/cleanarch/domain/model/User.java
+++ b/src/main/java/com/finance/manager/cleanarch/domain/model/User.java
@@ -16,9 +16,9 @@ public final class User {
   private static final String PASSWORD_PATTERN = 
       "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=!])(?=\\S+$).{8,}$";
   private static final String EMAIL_PATTERN =
-      "^[A-Za-z0-9+_.-]+@"                                // Local part
+      "^[A-Za-z0-9][A-Za-z0-9+_.-]*[A-Za-z0-9]@"         // Local part with valid start/end
       + "[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?"      // Domain first part
-      + "(?:\\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+$"; // Domain other parts
+      + "(?:\\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+$";  // Domain parts
 
   @Setter
   private Long id;

--- a/src/test/java/com/finance/manager/cleanarch/domain/model/UserTest.java
+++ b/src/test/java/com/finance/manager/cleanarch/domain/model/UserTest.java
@@ -40,7 +40,10 @@ class UserTest {
     "test.example.com",
     "test@example",
     "test@@example.com",
-    "test@example..com"
+    "test@example..com",
+    ".@gmail.com",           // email starting with dot
+    ".test@example.com",     // local part starting with dot
+    "test.@example.com"      // local part ending with dot
   })
   @DisplayName("Should reject invalid emails")
   void isValidEmail_WithInvalidEmails_ReturnsFalse(String invalidEmail) {


### PR DESCRIPTION
This commit fixes an issue where invalid email formats like '.@gmail.com' and 'test.@example.com' were incorrectly accepted as valid.

Changes:
- Updated EMAIL_PATTERN regex in User.java to ensure local part starts and ends with alphanumeric character
- Added specific test cases for these edge cases in UserTest.java
- Improved comments for better code readability

This enhancement makes the email validation more robust and prevents users from registering with invalid email formats.